### PR TITLE
Release 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Luma | Routing Component Changelog
 
+## [1.6.1] - 2024-05-05
+### Added
+- Using `AbstractRouteProtectionAttribute`
+
+### Changed
+- N/A
+
+### Deprecated
+- N/A
+
+### Removed
+- N/A
+
+### Fixed
+- Fixed issue where route protection attributes were not respecting `redirectPath` and `message` arguments.
+
+### Security
+- N/A
+
+---
+
 ## [1.6.0] - 2024-05-05
 ### Added
 - Added `redirectPath` and `message` to route protection attributes

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <div>
 <!-- Version Badge -->
-<img src="https://img.shields.io/badge/Version-1.5.2-blue" alt="Version 1.5.2">
+<img src="https://img.shields.io/badge/Version-1.6.1-blue" alt="Version 1.6.1">
 <!-- PHP Coverage Badge -->
-<img src="https://img.shields.io/badge/PHP Coverage-73.85%25-orange" alt="PHP Coverage 73.85%">
+<img src="https://img.shields.io/badge/PHP Coverage-77.49%25-orange" alt="PHP Coverage 77.49%">
 <!-- License Badge -->
 <img src="https://img.shields.io/badge/License-GPL--3.0--or--later-34ad9b" alt="License GPL--3.0--or--later">
 </div>

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,6 @@
   "scripts": {
     "test": "php -d xdebug.mode=coverage ./vendor/bin/phpunit --testdox --colors=always --coverage-html coverage --coverage-clover coverage/coverage.xml --testdox-html coverage/testdox.html && npx badger --phpunit ./coverage/coverage.xml && npx badger --version ./composer.json && npx badger --license ./composer.json"
   },
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "GPL-3.0-or-later"
 }

--- a/src/Attribute/AbstractRouteProtectionAttribute.php
+++ b/src/Attribute/AbstractRouteProtectionAttribute.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Luma\RoutingComponent\Attribute;
+
+#[\Attribute(\Attribute::TARGET_METHOD)]
+class AbstractRouteProtectionAttribute
+{
+    public const string REDIRECT_PATH_KEY = 'redirectPath';
+    public const string MESSAGE_KEY = 'message';
+
+    public function __construct(?string $redirectPath = null, ?string $message = null)
+    {
+    }
+}

--- a/src/Attribute/RequireAuthentication.php
+++ b/src/Attribute/RequireAuthentication.php
@@ -3,13 +3,6 @@
 namespace Luma\RoutingComponent\Attribute;
 
 #[\Attribute(\Attribute::TARGET_METHOD)]
-class RequireAuthentication
+class RequireAuthentication extends AbstractRouteProtectionAttribute
 {
-    /**
-     * @param string|null $redirectPath
-     * @param string|null $message
-     */
-    public function __construct(string $redirectPath = null, string $message = null)
-    {
-    }
 }

--- a/src/Attribute/RequirePermissions.php
+++ b/src/Attribute/RequirePermissions.php
@@ -3,8 +3,10 @@
 namespace Luma\RoutingComponent\Attribute;
 
 #[\Attribute(\Attribute::TARGET_METHOD)]
-class RequirePermissions
+class RequirePermissions extends AbstractRouteProtectionAttribute
 {
+    public const string PERMISSIONS_KEY = 'permissions';
+
     /**
      * @param array $permissions
      * @param string|null $redirectPath
@@ -12,5 +14,6 @@ class RequirePermissions
      */
     public function __construct(array $permissions, string $redirectPath = null, string $message = null)
     {
+        parent::__construct($redirectPath, $message);
     }
 }

--- a/src/Attribute/RequireRoles.php
+++ b/src/Attribute/RequireRoles.php
@@ -3,8 +3,10 @@
 namespace Luma\RoutingComponent\Attribute;
 
 #[\Attribute(\Attribute::TARGET_METHOD)]
-class RequireRoles
+class RequireRoles extends AbstractRouteProtectionAttribute
 {
+    public const string ROLES_KEY = 'roles';
+
     /**
      * @param array $roles
      * @param string|null $redirectPath

--- a/src/Attribute/RequireUnauthenticated.php
+++ b/src/Attribute/RequireUnauthenticated.php
@@ -3,13 +3,6 @@
 namespace Luma\RoutingComponent\Attribute;
 
 #[\Attribute(\Attribute::TARGET_METHOD)]
-class RequireUnauthenticated
+class RequireUnauthenticated extends AbstractRouteProtectionAttribute
 {
-    /**
-     * @param string|null $redirectPath
-     * @param string|null $message
-     */
-    public function __construct(string $redirectPath = null, string $message = null)
-    {
-    }
 }

--- a/tests/Controllers/TestController.php
+++ b/tests/Controllers/TestController.php
@@ -76,4 +76,10 @@ class TestController
     {
         return 'Success';
     }
+
+    #[RequireUnauthenticated(redirectPath: '/', message: 'You must be signed out to view this page.')]
+    public function notAuthenticatedWithArgumentsSuccess(): string
+    {
+        return 'Success';
+    }
 }

--- a/tests/Unit/RouterTest.php
+++ b/tests/Unit/RouterTest.php
@@ -258,7 +258,7 @@ class RouterTest extends TestCase
     {
         $this->router->loadRoutes([
             [
-                'path' => '/',
+                'path' => '/test-1',
                 'handler' => [
                     TestController::class,
                     'notAuthenticated',
@@ -266,7 +266,7 @@ class RouterTest extends TestCase
             ],
         ]);
 
-        $response = $this->router->handleRequest($this->buildGetRequest($this->buildUri('/')));
+        $response = $this->router->handleRequest($this->buildGetRequest($this->buildUri('/test-1')));
 
         $this->assertEquals('403 Not Allowed', $response->getBody()->getContents());
         $this->assertEquals(403, $response->getStatusCode());
@@ -281,7 +281,14 @@ class RouterTest extends TestCase
     {
         $this->router->loadRoutes([
             [
-                'path' => '/',
+                'path' => '/test-1',
+                'handler' => [
+                    TestController::class,
+                    'notAuthenticatedSuccess',
+                ],
+            ],
+            [
+                'path' => '/test-2',
                 'handler' => [
                     TestController::class,
                     'notAuthenticatedSuccess',
@@ -289,7 +296,12 @@ class RouterTest extends TestCase
             ],
         ]);
 
-        $response = $this->router->handleRequest($this->buildGetRequest($this->buildUri('/')));
+        $response = $this->router->handleRequest($this->buildGetRequest($this->buildUri('/test-1')));
+
+        $this->assertEquals('Success', $response->getBody()->getContents());
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $response = $this->router->handleRequest($this->buildGetRequest($this->buildUri('/test-2')));
 
         $this->assertEquals('Success', $response->getBody()->getContents());
         $this->assertEquals(200, $response->getStatusCode());


### PR DESCRIPTION
## [1.6.1] - 2024-05-05
### Added
- Using `AbstractRouteProtectionAttribute`

### Changed
- N/A

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- Fixed issue where route protection attributes were not respecting `redirectPath` and `message` arguments.

### Security
- N/A